### PR TITLE
Fix: Add Error Handling for Task Description Length Restriction

### DIFF
--- a/todo_list_app/src/main.py
+++ b/todo_list_app/src/main.py
@@ -21,5 +21,8 @@ def retrieve_task(task_id: int):
 
 @app.post("/tasks", tags=["Tasks"])
 def create_task(title: str, description: str):
+    if len(description) > 150:
+        raise HTTPException(status_code=400, detail="Description cannot exceed 150 characters.")
+    
     task = add_task(title, description)
     return task


### PR DESCRIPTION
This PR addresses issue where task creation fails if the description exceeds 150 characters, without proper error handling.

Changes Made:
Added a validation check in the POST /tasks route to enforce the 150-character limit.
If the description is too long, the API now returns a 400 Bad Request with a clear error message.
Testing:
Tested with a valid description (under 150 characters) → Task created successfully.
Tested with an invalid description (over 150 characters) → Returns 400 error with appropriate message.